### PR TITLE
Output Bug Fixes

### DIFF
--- a/src/MetaWinCharts.py
+++ b/src/MetaWinCharts.py
@@ -7,6 +7,8 @@ from typing import Optional, Tuple, Union
 
 from matplotlib import patches
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
+# the following import is necessary to force pyinstaller to include these backends for vector output when packaging
+from matplotlib.backends import backend_svg, backend_ps, backend_pgf, backend_pdf
 from matplotlib.figure import Figure
 from matplotlib.colors import XKCD_COLORS, hex2color
 import numpy

--- a/src/MetaWinCharts.py
+++ b/src/MetaWinCharts.py
@@ -46,6 +46,8 @@ UNFILLED_MARKERS = {"point", "plus", "X", "vertical line", "horizontal line", "t
                     "tick down", "upward caret", "downward caret", "left caret", "right caret",
                     "centered upward caret", "centered downward caret", "centered left caret", "centered right caret"}
 
+FIGURE_CANVAS = None
+
 
 # ---------- Chart Data Classes ---------- #
 class BaseChartData:
@@ -758,7 +760,19 @@ def base_figure():
     """
     create the baseline figure used for all plots
     """
-    figure_canvas = FigureCanvasQTAgg(Figure(figsize=(8, 6)))
+
+    # The following solution is a bit clunky, but serves to erase an existing figure prior to a new one
+    # being created. Without it, triggering the save figure action would serially try to save all figures that
+    # had been created in that session, rather than just the most recent.
+    # I have yet to come up with a better approach that works.
+    global FIGURE_CANVAS
+    if FIGURE_CANVAS is None:
+        figure_canvas = FigureCanvasQTAgg(Figure(figsize=(8, 6)))
+        FIGURE_CANVAS = figure_canvas
+    else:
+        figure_canvas = FIGURE_CANVAS
+        figure_canvas.figure.clf()
+
     faxes = figure_canvas.figure.subplots()
     faxes.spines["right"].set_visible(False)
     faxes.spines["top"].set_visible(False)

--- a/src/MetaWinConstants.py
+++ b/src/MetaWinConstants.py
@@ -13,7 +13,7 @@ mean_data_tuple = namedtuple("mean_data_tuple", ["name", "order", "n", "mean", "
 
 MAJOR_VERSION = 3
 MINOR_VERSION = 0
-PATCH_VERSION = 11
+PATCH_VERSION = 12
 
 # validity check when fetching value from data matrix
 VALUE_NUMBER = 0

--- a/src/MetaWinMain.py
+++ b/src/MetaWinMain.py
@@ -9,7 +9,7 @@ import sys
 from PyQt6.QtWidgets import QMainWindow, QTabWidget, QTableWidget, QFileDialog, QTableWidgetItem, QMenu, QInputDialog, \
     QApplication, QTextEdit, QColorDialog, QToolBar, QFrame, QHBoxLayout, QVBoxLayout, QLabel, QFontDialog, \
     QWidgetAction, QComboBox
-from PyQt6.QtGui import QIcon, QColor, QAction, QActionGroup
+from PyQt6.QtGui import QIcon, QColor, QAction, QActionGroup, QTextCursor
 from PyQt6 import QtCore
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT
 
@@ -315,7 +315,8 @@ class MainWindow(QMainWindow):
         self.main_area.addTab(output_frame, QIcon(MetaWinConstants.output_icon), get_text("Output"))
 
         # initial output text
-        self.write_output("<h1>MetaWin</h1>")
+        # the title is set directly in order to eliminate a stray blank lane at beginning of output
+        self.output_area.setHtml("<h1>MetaWin</h1>")
         self.write_output(MetaWinConstants.mw3_citation)
         self.write_output_block([version_str(),
                                  get_text("Started at ") + datetime.datetime.now().strftime("%B %d, %Y, %I:%M %p")])
@@ -524,7 +525,12 @@ class MainWindow(QMainWindow):
         """
         Add a string to the output text box, while storing the fact that the output has not been saved.
         """
-        self.output_area.append(output)
+        # self.output_area.append(output)
+        # this approach to adding text to the output is a workaround for what appears to be a Qt bug
+        #   while appended text looks fine when within the GUI, if exported toHtml() or toMarkdown() all lines
+        #   get converted to level 1 headers
+        self.output_area.setHtml(self.output_area.toHtml() + output)
+        self.output_area.moveCursor(QTextCursor.MoveOperation.End, QTextCursor.MoveMode.MoveAnchor)
         self.output_saved = False
 
     def row_header_popup(self, pos) -> None:

--- a/src/MetaWinMain.py
+++ b/src/MetaWinMain.py
@@ -654,7 +654,7 @@ class MainWindow(QMainWindow):
                 else:
                     outstr = self.output_area.toPlainText()
                 try:
-                    with open(save_name[0], "w") as outfile:
+                    with open(save_name[0], "w", encoding="utf8") as outfile:
                         outfile.writelines(outstr)
                     self.output_saved = True
                     return True

--- a/src/MetaWinMain.py
+++ b/src/MetaWinMain.py
@@ -509,10 +509,21 @@ class MainWindow(QMainWindow):
     def write_multi_output_blocks(self, output: list) -> None:
         """
         Given a list of lists of strings, write each sublist to the output area as a single block
+
+        Move cursor to the start of the new block
         """
+        # find position of end of current output
+        self.output_area.moveCursor(QTextCursor.MoveOperation.End, QTextCursor.MoveMode.MoveAnchor)
+        current_position = self.output_area.textCursor().position()
         for block in output:
             self.write_output_block(block)
-        self.write_output("")
+        self.write_output("<p></p>")
+        # reset cursor position to end, then set it back to end of previous block
+        # this causes viewpane to scroll so that new output is near top of view (if possible)
+        self.output_area.moveCursor(QTextCursor.MoveOperation.End, QTextCursor.MoveMode.MoveAnchor)
+        cursor = self.output_area.textCursor()
+        cursor.setPosition(current_position+1)
+        self.output_area.setTextCursor(cursor)
 
     def write_output_block(self, output: list) -> None:
         """
@@ -530,7 +541,6 @@ class MainWindow(QMainWindow):
         #   while appended text looks fine when within the GUI, if exported toHtml() or toMarkdown() all lines
         #   get converted to level 1 headers
         self.output_area.setHtml(self.output_area.toHtml() + output)
-        self.output_area.moveCursor(QTextCursor.MoveOperation.End, QTextCursor.MoveMode.MoveAnchor)
         self.output_saved = False
 
     def row_header_popup(self, pos) -> None:


### PR DESCRIPTION
Fixes a variety of bugs:
- Pre-packaged versions of MetaWin could not save figures in vector formats (closes #23)
- In some cases, text output could not be saved to a file without program closing (closes #24)
- If multiple figures were created in a single session, attempting to save the current figure to a file would cause program to serially try to save all of them, rather than just the current figure
- A workaround for a bug in Qt that was causing text output saved in HTML or Markdown formats to export all lines as level 1 headers

Tweak:
- The text output tab will now automatically scroll to display newly added text starting at the top of the window
